### PR TITLE
Add `libtesseract.dylib` to paths of `_get_*_tesseract_path` functions

### DIFF
--- a/src/tesseract/tesseract_utils.py
+++ b/src/tesseract/tesseract_utils.py
@@ -39,6 +39,7 @@ def _get_pyinstaller_tesseract_path():
         bundled_paths += [
             os.path.join(base_path, "libtesseract.so.5"),
             os.path.join(base_path, "libtesseract.so.4"),
+            os.path.join(base_path, "libtesseract.dylib"),
         ]
     return bundled_paths
 
@@ -59,6 +60,7 @@ def _get_config_tesseract_path():
             locations += [
                 os.path.join(configLocation, "libtesseract.so.5"),
                 os.path.join(configLocation, "libtesseract.so.4"),
+                os.path.join(configLocation, "libtesseract.dylib"),
             ]
     return locations
 


### PR DESCRIPTION
Fixes ["MacOS - Tesseract library was not found on your system. Please install it" #46
](https://github.com/chpoit/utsushis-charm/issues/46)